### PR TITLE
Исправлены подсказки типов в PHPDoc-блоках

### DIFF
--- a/src/SigHelper.php
+++ b/src/SigHelper.php
@@ -49,9 +49,9 @@ class SigHelper {
 	/**
 	 * Return concated string to make hash
 	 * 
-	 * @param type $scriptName
+	 * @param string $scriptName
 	 * @param array $params
-	 * @return type
+	 * @return string
 	 */
 	private function makeSigStr ( $scriptName, array $params ) {
 		if(!empty($params['pg_sig'])){
@@ -105,7 +105,7 @@ class SigHelper {
 	}
 
 	/**
-	 * @param type $secretKey
+	 * @param string $secretKey
 	 */
 	public function __construct($secretKey) {
 		$this->secretKey = $secretKey;

--- a/src/request/clients/PostClient.php
+++ b/src/request/clients/PostClient.php
@@ -11,9 +11,9 @@ use Psr\Log\LogLevel;
 
 class PostClient implements iClient {
 
-    /** @var Описание ошибки */
+    /** @var string|null Описание ошибки */
 	protected $errorDescription;
-	/** @var Код ошибки */
+	/** @var mixed|null Код ошибки */
 	protected $errorCode;
 	
 	/** @var int Номер магазина */
@@ -88,7 +88,6 @@ class PostClient implements iClient {
 	 * Проверить ответ на наличие ошибок
 	 * @param string $response
 	 * @param string $url
-	 * @param type $parameters Description
 	 * @return boolean
 	 */
 	protected function hasError($response, $url) {

--- a/src/request/data_objects/AviaGds.php
+++ b/src/request/data_objects/AviaGds.php
@@ -13,9 +13,9 @@ class AviaGds extends BaseData {
 	protected $pg_merchant_markup;
 	
 	/**
-	 * @param type $recLoc PNR
-	 * @param type $gds Название GDS (AMADUS|SABRE|GALILEO и т.д.)
-	 * @param type $markup Сумма надбавки магазина
+	 * @param string $recLoc PNR
+	 * @param string $gds Название GDS (AMADUS|SABRE|GALILEO и т.д.)
+	 * @param float $markup Сумма надбавки магазина
 	 */
 	public function __construct($recLoc, $gds, $markup) {
 		$this->pg_rec_log = $recLoc;

--- a/src/request/request_builders/InitPaymentBuilder.php
+++ b/src/request/request_builders/InitPaymentBuilder.php
@@ -38,7 +38,7 @@ class InitPaymentBuilder extends RequestBuilder {
 	/** @var boolean Отлиженный платеж */
 	protected $pg_postpone;
 
-	/** @var strind Язык транзакции */
+	/** @var string Язык транзакции */
 	protected $pg_language;
 
 	/** @var boolean Установлен ли демо режим */
@@ -209,7 +209,6 @@ class InitPaymentBuilder extends RequestBuilder {
 
 	/**
 	 * Установить язык транзакции
-	 * @param type $language
 	 * @return $this
 	 */
 	public function addLanguageEn() {
@@ -387,8 +386,9 @@ class InitPaymentBuilder extends RequestBuilder {
 
 	/**
 	 * Установить произвольные поля магазина
-	 * @param type $parameters
+	 * @param array $parameters
 	 * @return $this
+     * @throws Exception
 	 */
 	public function addMerchantParams($parameters) {
         foreach ($parameters as $name => $value) {
@@ -404,6 +404,7 @@ class InitPaymentBuilder extends RequestBuilder {
 	 * Установить дополнительные для ПС параметры (например, для альфаклик идентификатор в интернет банке)
 	 * @param array $parameters
 	 * @return $this
+     * @throws Exception
 	 */
 	public function addPsAdditionalParameters($parameters) {
 		foreach ($parameters as $name => $value) {

--- a/src/request/request_builders/InitPaymentBuilder.php
+++ b/src/request/request_builders/InitPaymentBuilder.php
@@ -388,7 +388,7 @@ class InitPaymentBuilder extends RequestBuilder {
 	 * Установить произвольные поля магазина
 	 * @param array $parameters
 	 * @return $this
-     * @throws Exception
+	 * @throws Exception
 	 */
 	public function addMerchantParams($parameters) {
         foreach ($parameters as $name => $value) {
@@ -404,7 +404,7 @@ class InitPaymentBuilder extends RequestBuilder {
 	 * Установить дополнительные для ПС параметры (например, для альфаклик идентификатор в интернет банке)
 	 * @param array $parameters
 	 * @return $this
-     * @throws Exception
+	 * @throws Exception
 	 */
 	public function addPsAdditionalParameters($parameters) {
 		foreach ($parameters as $name => $value) {

--- a/src/request/request_builders/MakeRecurringBuilder.php
+++ b/src/request/request_builders/MakeRecurringBuilder.php
@@ -84,7 +84,7 @@ class MakeRecurringBuilder extends RequestBuilder {
 
 	/**
 	 * Установить refund url в транзакцию
-	 * @param type $refundUrl
+	 * @param string $refundUrl
 	 * @return $this
 	 */
 	public function addRefundUrl($refundUrl) {
@@ -115,6 +115,7 @@ class MakeRecurringBuilder extends RequestBuilder {
 	/**
 	 * @param array $params Список дополнительных параметров магазина
 	 * @return $this
+     * @throws Exception
 	 */
 	public function addMerchantParams($params) {
 		foreach ($params as $name => $value) {

--- a/src/request/request_builders/MakeRecurringBuilder.php
+++ b/src/request/request_builders/MakeRecurringBuilder.php
@@ -115,7 +115,7 @@ class MakeRecurringBuilder extends RequestBuilder {
 	/**
 	 * @param array $params Список дополнительных параметров магазина
 	 * @return $this
-     * @throws Exception
+	 * @throws Exception
 	 */
 	public function addMerchantParams($params) {
 		foreach ($params as $name => $value) {

--- a/src/request/request_builders/RevokeBuilder.php
+++ b/src/request/request_builders/RevokeBuilder.php
@@ -29,7 +29,7 @@ class RevokeBuilder extends RequestBuilder {
 
 	/**
 	 * Установка суммы возврата. По умолчанию возвращается вся сумма
-	 * @param type $amount
+	 * @param float $amount
 	 */
 	public function setAmount($amount) {
 		$this->pg_refund_amount = $amount;


### PR DESCRIPTION
Чтобы PhpStorm и другие IDE не показывали предупреждения там, где всё в порядке. Например, в этом случае:

![image](https://user-images.githubusercontent.com/9006227/39794305-02e94478-538d-11e8-9df7-83c2343ff8e2.png)
