### PR TITLE
Небольшие исправления composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,18 +1,23 @@
 {
-    "name": "payprocessing/phpsdk",
-    "description": "Platron payment SDK",
-    "require": {
-        "php": ">=5.3",
-        "psr/log": "1.0.2"
-    },
-    "require-dev": {
+	"name": "payprocessing/phpsdk",
+	"description": "Platron payment SDK",
+	"license": "MIT",
+	"require": {
+		"php": ">=5.3",
+		"psr/log": "^1.0.2"
+	},
+	"require-dev": {
 		"php": ">=5.6",
-		"phpunit/phpunit": "5.7"
+		"phpunit/phpunit": "^5.7"
 	},
 	"autoload": {
 		"psr-4": {
-			"Platron\\PhpSdk\\": "src",
-                        "Platron\\PhpSdk\\tests\\": "tests"
+			"Platron\\PhpSdk\\": "src"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"Platron\\PhpSdk\\tests\\": "tests"
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -1,23 +1,23 @@
 {
-	"name": "payprocessing/phpsdk",
-	"description": "Platron payment SDK",
-	"license": "MIT",
-	"require": {
-		"php": ">=5.3",
-		"psr/log": "^1.0.2"
-	},
-	"require-dev": {
-		"php": ">=5.6",
-		"phpunit/phpunit": "^5.7"
-	},
-	"autoload": {
-		"psr-4": {
-			"Platron\\PhpSdk\\": "src"
-		}
-	},
-	"autoload-dev": {
-		"psr-4": {
-			"Platron\\PhpSdk\\tests\\": "tests"
-		}
-	}
+    "name": "payprocessing/phpsdk",
+    "description": "Platron payment SDK",
+    "license": "MIT",
+    "require": {
+        "php": ">=5.3",
+        "psr/log": "^1.0.2"
+    },
+    "require-dev": {
+        "php": ">=5.6",
+        "phpunit/phpunit": "^5.7"
+    },
+    "autoload": {
+        "psr-4": {
+            "Platron\\PhpSdk\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Platron\\PhpSdk\\tests\\": "tests"
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.3",
-        "psr/log": "^1.0.2"
+        "psr/log": "^1.0"
     },
     "require-dev": {
         "php": ">=5.6",


### PR DESCRIPTION
* Классы тестов подключаются через автозагрузчик только в режиме разработки. Эти классы не будут подключаться, когда пакет будет уставлен в проекте как зависимость, что немного снизит нагрузку на автозагрузчик.
* Указаны менее специфичные версии зависимостей (симсол `^` перед номером версии говорит о том, что подойдёт любая версия, обратно совместимая с указанной).
* Указана лицензия.