### PR TITLE
Поправил проверку vat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,8 @@ composer.phar
 # Netbeans project files
 /nbproject/
 
+# PHPStorm project files
+.idea/
+
 # Merchant settings for integration tests
 /tests/integration/MerchantSettings.php

--- a/src/request/data_objects/Item.php
+++ b/src/request/data_objects/Item.php
@@ -29,8 +29,10 @@ class Item extends BaseData {
 	 * @param string $vat Если отсутствует - не облягается налогом. Берется из констант
 	 */
 	public function __construct($label, $price, $quantity, $vat = null) {
-		if($vat && !in_array($vat, $this->getVatTypes())){
-			throw new \Platron\PhpSdk\Exception('Wrong vat. Use from constant');
+		if (!is_null($vat)) {
+			if (!in_array(strval($vat), $this->getVatTypes())) {
+				throw new \Platron\PhpSdk\Exception('Wrong vat. Use from constant');
+			}
 		}
 		
 		$this->pg_label = $label;

--- a/tests/unit/request/data_objects/ItemTest.php
+++ b/tests/unit/request/data_objects/ItemTest.php
@@ -23,11 +23,24 @@ class ItemTest extends PHPUnit_Framework_TestCase {
 	public function testExceptionSetVat(){
 		try {
 			new Item('test product', '10.00', 2, 'wrong value');
+			$this->fail();
 		} catch (Exception $ex) {
-			return true;
+			$this->assertInstanceOf('\Platron\PhpSdk\Exception', $ex);
 		}
-		
-		return false;
+
+		try {
+			new  Item('test product', '10.00', 2, '');
+		 	$this->fail();
+		} catch (Exception $ex) {
+			$this->assertInstanceOf('\Platron\PhpSdk\Exception', $ex);
+		}
+
+		try {
+			new Item('test product', '10.00', 2, false);
+			$this->fail();
+		} catch (Exception $ex) {
+			$this->assertInstanceOf('\Platron\PhpSdk\Exception', $ex);
+		}
 	}
 	
 }


### PR DESCRIPTION
Если сделать
```php
$item = new Item('test product', '10.00', 2, false);
$parameters = $item->getParameters();
```
  'pg_vat' => bool(false)

Поправил проверку vat в конструкторе \Platron\PhpSdk\request\data_objects\Item