### PR TITLE
Убран необязательный параметр, если он не указан, из формирования подписи

### DIFF
--- a/src/SigHelper.php
+++ b/src/SigHelper.php
@@ -65,6 +65,10 @@ class SigHelper
 		array_unshift($params, $scriptName);
 		array_push($params, $this->secretKey);
 
+        if (isset($params['pg_template004pg_max_periods004']) && $params['pg_template004pg_max_periods004'] == '') {
+            unset($params['pg_template004pg_max_periods004']);
+        }
+
 		return join(';', $params);
 	}
 


### PR DESCRIPTION
В случае рекуррентных платежей, если не указать параметр макс. кол-ва периодов, он фигурирует в подписи как пустая строка. На стороне платрона при инициализации создания расписания он не участвует.